### PR TITLE
Re-use cooked

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,10 +67,16 @@ function run() {
 
     source = data
 
-    var next = parsed.argv.remain.shift()
+    var next = parsed.argv.cooked.shift()
 
     if(!next || next === '--') {
       return process.stdout.write(pre + source)
+    }
+    if (next === '--falafelOptions'){
+      if (parsed.argv.cooked.length > 0){
+        parsed.argv.cooked.shift();
+      }
+      return got_source(null, source);
     }
 
     transform = parse_transform(


### PR DESCRIPTION
Hi Chris,
My apologies, I neglected to test how things would work with the -- separator after my changes. This should restore the ability to have 'transform' arguments separate from rewritejs arguments.
